### PR TITLE
Created devices usescase tests, modified load config, removed duplica…

### DIFF
--- a/config/app_config.go
+++ b/config/app_config.go
@@ -41,19 +41,32 @@ func LoadConfig() {
 	}
 
 	currentEnvironment, ok := os.LookupEnv(DEFAULT_KEY_FOR_CONFIG)
-	envPath := "../"
 
 	fmt.Println("enviroment", currentEnvironment, ok)
 
 	if len(currentEnvironment) == 0 || currentEnvironment == "PROD" {
 		currentEnvironment = "PROD"
-		envPath = "./"
 	}
 
-	err := godotenv.Load(envPath + currentEnvironment + ".env")
+	possiblePaths := []string{"", "./", "../", "../../", "../../../"}
 
-	if err != nil {
-		panic(err)
+	found := false
+
+	for _, e := range possiblePaths {
+
+		err := godotenv.Load(e + currentEnvironment + ".env")
+
+		if err != nil {
+			continue
+		}
+
+		found = true
+		break
+
+	}
+
+	if !found {
+		log.Fatal("could not find proper .env file")
 	}
 
 	for _, e := range varLists {

--- a/database/database.go
+++ b/database/database.go
@@ -308,7 +308,7 @@ func DeleteDeviceByID(id string) error {
 
 }
 
-func deleteAllDevices() error {
+func DeleteAllDevices() error {
 
 	if dbClient == nil {
 		return errors.New(string(ErrorDBNotConnected))

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -35,7 +35,7 @@ func mainSetup() {
 }
 
 func teardown() {
-	deleteAllDevices()
+	DeleteAllDevices()
 }
 
 func TestDefaultTimeForDB(t *testing.T) {
@@ -305,7 +305,7 @@ func TestGetAllDevicesByField(t *testing.T) {
 
 func TestDeleteDeviceByid(t *testing.T) {
 
-	dbError := deleteAllDevices()
+	dbError := DeleteAllDevices()
 
 	if dbError != nil {
 		t.Errorf("got %s, expected %s", dbError, "nil")

--- a/domain/domain_devices.go
+++ b/domain/domain_devices.go
@@ -13,7 +13,7 @@ const TagModificationTime string = "modification_time"
 const TagCreationTime string = "creation_time"
 const DefaultInitState = DeviceStatusAvalaible
 
-const MaxLenID = 150
+const MaxLenID = 50
 const MaxLenBrand = 30
 const MaxLenName = 45
 

--- a/useCase/devices/create_test.go
+++ b/useCase/devices/create_test.go
@@ -1,0 +1,174 @@
+package usecase_devices
+
+import (
+	"errors"
+	"log"
+	"os"
+	"strconv"
+	app_config "test-devices-api/config"
+	"test-devices-api/database"
+	domain_devices "test-devices-api/domain"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	mainSetup()
+	exitCode := m.Run()
+	teardown()
+	os.Exit(exitCode)
+}
+
+func mainSetup() {
+
+	errorSet := os.Setenv(app_config.DEFAULT_KEY_FOR_CONFIG, "TEST")
+
+	if errorSet != nil {
+		log.Fatal(errorSet)
+	}
+
+	app_config.LoadConfig()
+
+	database.Connect()
+
+}
+
+func teardown() {
+	database.DeleteAllDevices()
+}
+
+func TestCreate(t *testing.T) {
+
+	var testList = []struct {
+		input         domain_devices.Devices
+		expectedError error
+		expectedRes   string
+	}{
+		{
+			input: domain_devices.Devices{
+				Name: "test4",
+			}, expectedError: errors.New(string(ErrorInvalidBrand)),
+			expectedRes: "",
+		},
+		{
+			input: domain_devices.Devices{
+				Brand: "0j1f0201290fj0fffffffffffffffffaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffffffffffffff",
+				Name:  "test4",
+			},
+			expectedError: errors.New(string(ErrorInvalidBrand)),
+			expectedRes:   "",
+		},
+		{
+			input:         domain_devices.Devices{Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Brand: "test2"},
+			expectedError: errors.New(string(ErrorInvalidName)),
+			expectedRes:   "",
+		},
+		{
+			input:         domain_devices.Devices{Brand: "test2"},
+			expectedError: errors.New(string(ErrorInvalidName)),
+			expectedRes:   "",
+		},
+		{
+			input:         domain_devices.Devices{Brand: "test2", Name: "test1"},
+			expectedError: nil,
+			expectedRes:   "id",
+		},
+	}
+
+	for i, e := range testList {
+
+		idCreation, errCreation := Create(e.input)
+
+		if errCreation != nil && e.expectedError != nil && e.expectedError.Error() != errCreation.Error() {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), errCreation, e.expectedError)
+			return
+		}
+
+		if e.expectedRes == "id" && len(idCreation) == 0 {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), "empty string", "creation id")
+			return
+		}
+
+	}
+
+}
+
+func TestValidateDeviceDataForCreation(t *testing.T) {
+
+	var testList = []struct {
+		input         domain_devices.Devices
+		expectedError error
+	}{
+		{
+			input: domain_devices.Devices{
+				Name: "test4",
+			}, expectedError: errors.New(string(ErrorInvalidBrand)),
+		},
+		{
+			input: domain_devices.Devices{
+				Brand: "0j1f0201290fj0fffffffffffffffffaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffffffffffffff",
+				Name:  "test4",
+			},
+			expectedError: errors.New(string(ErrorInvalidBrand)),
+		},
+		{
+			input:         domain_devices.Devices{Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Brand: "test2"},
+			expectedError: errors.New(string(ErrorInvalidName)),
+		},
+		{
+			input:         domain_devices.Devices{Brand: "test2"},
+			expectedError: errors.New(string(ErrorInvalidName)),
+		},
+		{
+			input:         domain_devices.Devices{Brand: "test2", Name: "test1"},
+			expectedError: nil,
+		},
+	}
+
+	for i, e := range testList {
+
+		errValidation := validateDeviceDataForCreation(&e.input)
+
+		if errValidation != nil && e.expectedError != nil && e.expectedError.Error() != errValidation.Error() {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), errValidation, e.expectedError)
+			return
+		}
+
+	}
+
+	var testList2 = []struct {
+		input       domain_devices.Devices
+		expectedRes domain_devices.Devices
+	}{
+		{
+			input: domain_devices.Devices{
+				Name:  "TESTE4 ",
+				Brand: "   ATT",
+			}, expectedRes: domain_devices.Devices{
+				Name:  "teste4",
+				Brand: "att",
+			},
+		},
+	}
+
+	for i, e := range testList2 {
+
+		errValidation := validateDeviceDataForCreation(&e.input)
+
+		if errValidation != nil {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), errValidation, "")
+			return
+		}
+
+		if e.input.Brand != e.expectedRes.Brand {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), e.input.Brand, e.expectedRes.Brand)
+			return
+		}
+
+		if e.input.Name != e.expectedRes.Name {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), e.input.Name, e.expectedRes.Name)
+			return
+		}
+
+	}
+
+}

--- a/useCase/devices/delete_test.go
+++ b/useCase/devices/delete_test.go
@@ -1,0 +1,60 @@
+package usecase_devices
+
+import (
+	"errors"
+	"strconv"
+	"test-devices-api/database"
+	domain_devices "test-devices-api/domain"
+	"testing"
+)
+
+func TestDeleteDeviceByID(t *testing.T) {
+
+	c1 := domain_devices.Devices{Name: "testea", Brand: "testeb"}
+
+	idCreation, errCreation := Create(c1)
+
+	if errCreation != nil {
+		t.Errorf("got %s, expected %s", errCreation, "nil")
+		return
+	}
+
+	var testList = []struct {
+		input         string
+		expectedError error
+	}{
+		{
+			input: "fja09faj0affafffffffffffffffffffffffffffffffffffffffffffffdddddddddddddd", expectedError: errors.New(string(ErrorInvalidDeviceId)),
+		},
+		{
+			input: "", expectedError: errors.New(string(ErrorInvalidDeviceId)),
+		},
+		{
+			input: idCreation, expectedError: nil,
+		},
+	}
+
+	for i, e := range testList {
+
+		errorDelete := DeleteDeviceById(e.input)
+
+		if errorDelete != nil && e.expectedError != nil && e.expectedError.Error() != errorDelete.Error() {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), errorDelete, e.expectedError)
+			return
+		}
+
+	}
+
+	device, errorGetDeviceById := database.GetDeviceByID(idCreation)
+
+	if errorGetDeviceById != nil {
+		t.Errorf("got %s, expected %s", errCreation, "nil")
+		return
+	}
+
+	if len(device.Brand) > 0 {
+		t.Errorf("got %s, expected %s", "existing struct", "empty struct")
+		return
+	}
+
+}

--- a/useCase/devices/get.go
+++ b/useCase/devices/get.go
@@ -9,8 +9,6 @@ import (
 
 type DeviceGetErrors string
 
-const ()
-
 func GetDeviceById(deviceId string) (*domain_devices.Devices, error) {
 
 	if len(deviceId) == 0 || len(deviceId) > domain_devices.MaxLenID {

--- a/useCase/devices/get_test.go
+++ b/useCase/devices/get_test.go
@@ -1,0 +1,229 @@
+package usecase_devices
+
+import (
+	"errors"
+	"strconv"
+	"test-devices-api/database"
+	domain_devices "test-devices-api/domain"
+	"testing"
+	"time"
+)
+
+func TestGetDeviceById(t *testing.T) {
+
+	c1 := domain_devices.Devices{Name: "testea", Brand: "testeb"}
+
+	idCreation, errCreation := Create(c1)
+
+	if errCreation != nil {
+		t.Errorf("got %s, expected %s", errCreation, "nil")
+		return
+	}
+
+	deviceData, errorGet := GetDeviceById(idCreation)
+
+	if errorGet != nil {
+		t.Errorf("got %s, expected %s", errorGet, "nil")
+		return
+	}
+
+	if deviceData.Brand != c1.Brand {
+		t.Errorf("got %s, expected %s", "brand "+deviceData.Brand, c1.Brand)
+		return
+	}
+
+	if deviceData.Name != c1.Name {
+		t.Errorf("got %s, expected %s", "name "+deviceData.Name, c1.Name)
+		return
+	}
+
+	errorDeleting := database.DeleteDeviceByID(idCreation)
+
+	if errorDeleting != nil {
+		t.Errorf("got %s, expected %s", errorDeleting, "nil")
+		return
+	}
+
+	time.Sleep(1 * time.Second)
+
+	deviceData2, errorGet := GetDeviceById(idCreation)
+
+	if errorGet != nil {
+		t.Errorf("got %s, expected %s", errorGet, "nil")
+		return
+	}
+
+	if len(deviceData2.Brand) != 0 {
+		t.Errorf("got %s, expected %s", "existing struct", "empty struct")
+		return
+	}
+
+	_, errorGet2 := GetDeviceById("")
+
+	if errorGet2 != nil && errorGet2.Error() != ErrorInvalidDeviceId {
+		t.Errorf("got %s, expected %s", errorGet2, ErrorInvalidDeviceId)
+		return
+	}
+
+	_, errorGet3 := GetDeviceById("fJ8FJ89AF89AJ9F8AJ89FJ89AJF89AJF98AJ9F8AJ89FJA98JA89GJA89GJA98GJA98GJ98AJD89AJF98AJ9FAJ89FJA8989FA9J")
+
+	if errorGet3 != nil && errorGet3.Error() != ErrorInvalidDeviceId {
+		t.Errorf("got %s, expected %s", errorGet3, ErrorInvalidDeviceId)
+		return
+	}
+
+}
+
+func TestGetAllDevicesWithFilters(t *testing.T) {
+
+	var testList = []struct {
+		input         domain_devices.Devices
+		expectedError error
+	}{
+		{
+			input: domain_devices.Devices{
+				Name: "test4aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			}, expectedError: errors.New(string(ErrorInvalidName)),
+		},
+		{
+			input: domain_devices.Devices{
+				Brand: "0j1f0201290fj0fffffffffffffffffaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffaaaaaaaaaaaffffffffffff",
+			},
+			expectedError: errors.New(string(ErrorInvalidBrand)),
+		},
+		{
+			input: domain_devices.Devices{
+				State: "AvaLaible",
+			},
+			expectedError: errors.New(string(ErrorInvalidState)),
+		},
+		{
+			input:         domain_devices.Devices{},
+			expectedError: nil,
+		},
+		{
+			input:         domain_devices.Devices{State: domain_devices.DeviceStatusInUse},
+			expectedError: nil,
+		},
+	}
+
+	for i, e := range testList {
+
+		_, errorGet := GetAllDevicesWithFilters(e.input)
+
+		if errorGet != nil && e.expectedError != nil && e.expectedError.Error() != errorGet.Error() {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), errorGet, e.expectedError)
+			return
+		}
+
+	}
+
+	c1 := domain_devices.Devices{
+		Name:  "testeC",
+		Brand: "testec",
+	}
+
+	_, errorCreation := Create(c1)
+
+	if errorCreation != nil {
+		t.Errorf("got %s, expected %s", errorCreation, "nil")
+		return
+	}
+
+	time.Sleep(1 * time.Second)
+
+	list, errorGet := GetAllDevicesWithFilters(c1)
+
+	if errorGet != nil {
+		t.Errorf("got %s, expected %s", errorGet, "nil")
+		return
+	}
+
+	if len(*list) != 1 {
+		t.Errorf("got %s, expected %s", "list with "+strconv.Itoa(len(*list)), "1")
+		return
+	}
+
+}
+
+func TestValidateDeviceDataForFilter(t *testing.T) {
+
+	var testList = []struct {
+		input         domain_devices.Devices
+		expectedError error
+	}{
+		{
+			input: domain_devices.Devices{
+				Name: "test4aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			}, expectedError: errors.New(string(ErrorInvalidName)),
+		},
+		{
+			input: domain_devices.Devices{
+				Brand: "0j1f0201290fj0fffffffffffffffffaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffaaaaaaaaaaaffffffffffff",
+			},
+			expectedError: errors.New(string(ErrorInvalidBrand)),
+		},
+		{
+			input: domain_devices.Devices{
+				State: "AvaLaible",
+			},
+			expectedError: errors.New(string(ErrorInvalidState)),
+		},
+		{
+			input:         domain_devices.Devices{},
+			expectedError: nil,
+		},
+		{
+			input:         domain_devices.Devices{State: domain_devices.DeviceStatusInUse},
+			expectedError: nil,
+		},
+	}
+
+	for i, e := range testList {
+
+		errValidation := validateDeviceDataForFilter(&e.input)
+
+		if errValidation != nil && e.expectedError != nil && e.expectedError.Error() != errValidation.Error() {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), errValidation, e.expectedError)
+			return
+		}
+
+	}
+
+	var testList2 = []struct {
+		input       domain_devices.Devices
+		expectedRes domain_devices.Devices
+	}{
+		{
+			input: domain_devices.Devices{
+				Name:  "TESTE4 ",
+				Brand: "   ATT",
+			}, expectedRes: domain_devices.Devices{
+				Name:  "teste4",
+				Brand: "att",
+			},
+		},
+	}
+
+	for i, e := range testList2 {
+
+		errValidation := validateDeviceDataForFilter(&e.input)
+
+		if errValidation != nil {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), errValidation, "")
+			return
+		}
+
+		if e.input.Brand != e.expectedRes.Brand {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), e.input.Brand, e.expectedRes.Brand)
+			return
+		}
+
+		if e.input.Name != e.expectedRes.Name {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), e.input.Name, e.expectedRes.Name)
+			return
+		}
+
+	}
+
+}

--- a/useCase/devices/update.go
+++ b/useCase/devices/update.go
@@ -2,7 +2,6 @@ package usecase_devices
 
 import (
 	"errors"
-	"strings"
 	"test-devices-api/database"
 	domain_devices "test-devices-api/domain"
 )
@@ -20,7 +19,7 @@ func Update(deviceId string, deviceData domain_devices.Devices) error {
 		return errors.New(string(ErrorInvalidDeviceId))
 	}
 
-	errorValidacao := validateDeviceDataForUpdate(&deviceData)
+	errorValidacao := validateDeviceDataForFilter(&deviceData)
 
 	if errorValidacao != nil {
 		return errorValidacao
@@ -40,42 +39,6 @@ func Update(deviceId string, deviceData domain_devices.Devices) error {
 
 	if errorUpdate != nil {
 		return errorUpdate
-	}
-
-	return nil
-
-}
-
-func validateDeviceDataForUpdate(deviceData *domain_devices.Devices) error {
-
-	if len(deviceData.Brand) > 0 {
-
-		if brandLen := len(deviceData.Brand); brandLen > domain_devices.MaxLenBrand {
-			return errors.New(string(ErrorInvalidBrand))
-		}
-
-		deviceData.Brand = strings.ToLower(strings.Trim(deviceData.Brand, " "))
-
-	}
-
-	if len(deviceData.Name) > 0 {
-
-		if nameLen := len(deviceData.Name); nameLen > domain_devices.MaxLenName {
-			return errors.New(string(ErrorInvalidName))
-		}
-
-		deviceData.Name = strings.ToLower(strings.Trim(deviceData.Name, " "))
-
-	}
-
-	if len(deviceData.State) > 0 {
-
-		errorValidatingState := validateState(deviceData.State)
-
-		if errorValidatingState != nil {
-			return errorValidatingState
-		}
-
 	}
 
 	return nil

--- a/useCase/devices/update_test.go
+++ b/useCase/devices/update_test.go
@@ -1,0 +1,76 @@
+package usecase_devices
+
+import (
+	"errors"
+	"strconv"
+	"test-devices-api/database"
+	domain_devices "test-devices-api/domain"
+	"testing"
+)
+
+func TestUpdate(t *testing.T) {
+
+	c1 := domain_devices.Devices{
+		Name:  "testeG",
+		Brand: "testeG",
+	}
+
+	creationId, errorCreation := Create(c1)
+
+	if errorCreation != nil {
+		t.Errorf("got %s, expected %s", errorCreation, "nil")
+		return
+	}
+
+	var testList = []struct {
+		input         domain_devices.Devices
+		expectedError error
+	}{
+		{
+			input: domain_devices.Devices{}, expectedError: errors.New(string(database.ErrorEmptyUpdateMap)),
+		},
+		{
+			input: domain_devices.Devices{
+				Name: "test4aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			}, expectedError: errors.New(string(ErrorInvalidName)),
+		},
+		{
+			input: domain_devices.Devices{
+				Brand: "0j1f0201290fj0fffffffffffffffffaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffaaaaaaaaaaaffffffffffff",
+			},
+			expectedError: errors.New(string(ErrorInvalidBrand)),
+		},
+		{
+			input: domain_devices.Devices{
+				Brand: "novo",
+			},
+			expectedError: nil,
+		},
+		{
+			input: domain_devices.Devices{
+				State: "AvaLaible",
+			},
+			expectedError: errors.New(string(ErrorInvalidState)),
+		},
+		{
+			input:         domain_devices.Devices{State: domain_devices.DeviceStatusInUse},
+			expectedError: nil,
+		},
+		{
+			input:         domain_devices.Devices{Brand: "NOVO"},
+			expectedError: errors.New(ErrorDeviceInUse),
+		},
+	}
+
+	for i, e := range testList {
+
+		errorUpdate := Update(creationId, e.input)
+
+		if errorUpdate != nil && e.expectedError != nil && e.expectedError.Error() != errorUpdate.Error() {
+			t.Errorf("test idx %s, got %s, expected %s", strconv.Itoa(i), errorUpdate, e.expectedError)
+			return
+		}
+
+	}
+
+}


### PR DESCRIPTION
…ted function

- Device's usecases tests read

- Removed duplicated function validate validateDeviceDataForUpdate as validateDeviceDataForFilter does the same.

- Created a bypass for relative path errors on tests load .envs

x - Change the name of the validateDeviceDataForFilter name for generic situations

x - Get relative path on load env without brute force.