### PR TITLE
Changed the behaviour of delete device by id

### DIFF
--- a/config/app_config.go
+++ b/config/app_config.go
@@ -43,11 +43,11 @@ func LoadConfig() {
 
 	currentEnvironment, ok := os.LookupEnv(DEFAULT_KEY_FOR_CONFIG)
 
-	fmt.Println("enviroment", currentEnvironment, ok)
-
 	if len(currentEnvironment) == 0 {
 		currentEnvironment = "PROD"
 	}
+
+	fmt.Println("environment", currentEnvironment, ok)
 
 	possiblePaths := []string{"", "./", "../", "../../", "../../../"}
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -136,7 +136,7 @@ func TestUpdateDeviceByID(t *testing.T) {
 		{
 			input1:      "iOAJDOajdioa",
 			input2:      domain_devices.Devices{Brand: "aa"},
-			expectedRes: primitive.ErrInvalidHex,
+			expectedRes: errors.New(string(ErrorInvalidID)),
 		},
 	}
 
@@ -221,6 +221,13 @@ func TestGetDeviceById(t *testing.T) {
 
 	if len(deviceData2.Brand) != 0 {
 		t.Errorf("got %s, expected %s", deviceData2.Brand, "empty struct")
+		return
+	}
+
+	errorDeleting2 := DeleteDeviceByID(creationId)
+
+	if errorDeleting2 != nil {
+		t.Errorf("got %s, expected %s", errorDeleting2, "nil")
 		return
 	}
 

--- a/routes/handlers_test.go
+++ b/routes/handlers_test.go
@@ -30,7 +30,7 @@ func mainSetup() {
 	}
 
 	app_config.LoadConfig()
-	//routes.SetRoutesAuth(os.Getenv(secrets.KEY_EXTERNAL_AUTH))
+
 	database.Connect()
 
 }


### PR DESCRIPTION
- DeleteDeviceByID will return no error if the device id doesn't exist in DB.

- Created a test for the new behaviour of DeleteDeviceByID

- When the convertion of string to OBJID fails, it will return "invalid device id" instead of the native Error from the primite.OBJID method.